### PR TITLE
Fix highscore saving

### DIFF
--- a/qml/qml2048/ScoreArea.qml
+++ b/qml/qml2048/ScoreArea.qml
@@ -11,7 +11,9 @@ Row {
         if (boardSize == null)
             boardSize = currentBoardSize
 
-        storeHighscore()
+        if (bestItem.value > 0)
+            storeHighscore()
+
         currentBoardSize = boardSize
         scoreItem.value = 0
         bestItem.value = Storage.getHighscore(boardSize)

--- a/qml/qml2048/main.qml
+++ b/qml/qml2048/main.qml
@@ -5,7 +5,10 @@ import "storage.js" as Storage
 PageStackWindow {
     id: appWindow
     initialPage: mainPage
-    Component.onCompleted: mainPage.newGameRequest()
+    Component.onCompleted: {
+        mainPage.newGameRequest()
+        slider.valueChanged.connect(function() { mainPage.newGameRequest(slider.value) })
+    }
 
     MainPage {
         id: mainPage
@@ -44,7 +47,6 @@ PageStackWindow {
                     stepSize: 1
                     valueIndicatorVisible: true
                     width: parent.width
-                    onValueChanged: mainPage.newGameRequest(value)
                 }
             }
             MenuItem {


### PR DESCRIPTION
- **Prevent saving of 0 highscore to database at startup**

ScoreArea.reset() is called on startup causing saving 0 highscore to database
- **connect slider.valueChanged to newGameRequest after component completed**

slider.valueChanged will called even _before_ component is completed and the slider is not moved. This will cause newGameRequest called twice (one when slider valueChanged, one when component completed)
